### PR TITLE
Remove duplicate, empty Dutch translation

### DIFF
--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -1,2 +1,0 @@
-<resources>
-    </resources>


### PR DESCRIPTION
There is already one for "nl", so "nl-rNL" is redundant.