### PR TITLE
Add Chinese (zh-TW) translation template for app strings and GPlay

### DIFF
--- a/app/src/main/play/listings/zh-TW/full-description.txt
+++ b/app/src/main/play/listings/zh-TW/full-description.txt
@@ -1,0 +1,13 @@
+⚡ Revival of the app which was abandoned years ago.
+
+✅ Safety warning: Please always ensure that you have backed up your data by other means and that this backup is up to date before using this app. The app is still in early development.
+
+⚠️ We assume no liability for data corruption or loss, although we make every effort to deliver quality.
+
+This is an Android app which you can use as a client to access Syncthing shares offered by remote devices. It works similar to file sharing apps  accessing their server. 
+
+This is a client-oriented implementation, designed to work online by downloading and uploading files from an active device on the network instead of synchronizing a local copy of the entire folder. Due to that, you will see a sync progress of 0% at other devices which is expected. This is useful for devices where you don't want to download the entire contents of a shared folder. For example, mobile devices with limited storage available where you like to access a syncthing shared folder. This is quite different from the way the Syncthing-Fork app works.
+
+Please note that for technical reasons you can't reconnect via relay connection for some minutes after the app was closed. This may happen due to removing from the recent apps list, force close or an interrupted connection to remote device. This constraint does not apply for connections directly established through the local network.
+
+Source code: https://github.com/Catfriend1/syncthing-lite

--- a/app/src/main/play/listings/zh-TW/short-description.txt
+++ b/app/src/main/play/listings/zh-TW/short-description.txt
@@ -1,0 +1,1 @@
+Browse Syncthing shares

--- a/app/src/main/play/listings/zh-TW/title.txt
+++ b/app/src/main/play/listings/zh-TW/title.txt
@@ -1,0 +1,1 @@
+Syncthing-Lite

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,2 +1,0 @@
-<resources>
-    </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,2 @@
+<resources>
+</resources>


### PR DESCRIPTION
Empty template for strings, English version for Play listings.

Remove empty Portuguese (pt-PT) translation templates while we're at it.  Never touched in 7 years, and there is another Portuguese variant.

