### PR TITLE
Add Azerbaijani (az) and Kurdish (ckb) l10n templates

### DIFF
--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>


### PR DESCRIPTION
Empty template for strings.  Neither language seems to be supported on Google Play for listings.

Based on user requests from Weblate:

* `@miryusifrahimov` for Azerbaijani
* `@halbast` für Kurdish (Central)

Both seem to be legit and have previously contributed translations on Weblate.